### PR TITLE
WKT Multipoint: Add testcase & fix a bug that was introduced

### DIFF
--- a/src/test/ProphetRouterTest.java
+++ b/src/test/ProphetRouterTest.java
@@ -139,13 +139,13 @@ public class ProphetRouterTest extends AbstractRouterTest {
 		disconnect(h5);
 
 		clock.advance(SECONDS_IN_TIME_UNIT * 2);
-		double newPred = ProphetRouter.P_INIT * Math.pow(ProphetRouter.GAMMA,2);
+		double newPred = ProphetRouter.P_INIT * Math.pow(ProphetRouter.DEFAULT_GAMMA,2);
 
 		assertEquals(newPred, r4.getPredFor(h5));
 		assertEquals(newPred, r5.getPredFor(h4));
 
 		clock.advance(SECONDS_IN_TIME_UNIT / 10);
-		newPred = newPred *	Math.pow(ProphetRouter.GAMMA, 1.0/10);
+		newPred = newPred *	Math.pow(ProphetRouter.DEFAULT_GAMMA, 1.0/10);
 
 		assertEquals(newPred, r4.getPredFor(h5));
 		assertEquals(newPred, r5.getPredFor(h4));

--- a/src/test/WKTPointReaderTest.java
+++ b/src/test/WKTPointReaderTest.java
@@ -23,6 +23,11 @@ public class WKTPointReaderTest extends TestCase {
 		"LINESTRING (1.0 2.0, 2.0 3.0)\n"+ // should skip this line
 		"POINT (2552782.3212060533 6673285.5993876355)\n";
 
+	private final String MULTIPOINT_DATA =
+		"MULTIPOINT (2552448.388211649 6673384.4020657055, 2552275.9398973365 6673509.820852942) \n"+
+		"LINESTRING (1.0 2.0, 2.0 3.0)\n"+ // should skip this line
+		"MULTIPOINT ((2552361.289603607 6673630.088457832), (2552782.3212060533 6673285.5993876355))\n";
+
 	private final Coord[] POINTS = {
 			new Coord(2552448.388211649, 6673384.4020657055),
 			new Coord(2552275.9398973365, 6673509.820852942),
@@ -35,8 +40,19 @@ public class WKTPointReaderTest extends TestCase {
 		r = new WKTReader();
 	}
 
-	public void testReader() throws Exception {
+	public void testPointReader() throws Exception {
 		StringReader input = new StringReader(POINT_DATA);
+		List<Coord> coords = r.readPoints(input);
+
+		assertEquals(POINTS.length, coords.size());
+
+		for (int i=0; i<POINTS.length; i++) {
+			assertEquals(coords.get(i), POINTS[i]);
+		}
+	}
+
+	public void testMultipointReader() throws Exception {
+		StringReader input = new StringReader(MULTIPOINT_DATA);
 		List<Coord> coords = r.readPoints(input);
 
 		assertEquals(POINTS.length, coords.size());


### PR DESCRIPTION
The code did not work properly for special WKT strings that contain inner parentheses:
`MULTIPOINT ((x y), (x y))`

A test case was added to test these situations.
Some other bugs were fixed in the process as well